### PR TITLE
Implemented configurable ffmpeg options (Resolves #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Example `config.json` entry:
         ],
         "web_hook_port": "8443",
         "https_key_path": "/cert/privkey.pem",
-        "https_cert_path": "/cert/fullchain.pem"
+        "https_cert_path": "/cert/fullchain.pem",
+        "ffmpeg_input_args": "-fflags +genpts",
+        "ffmpeg_process_args": "-vsync drop -vcodec copy -an"
     }
 ]
 ```
@@ -41,6 +43,8 @@ Where:
 * `monitors` contains a list of monitors consisting of:
     * `monitor_id`
 * `web_hook_port` is the port that the platform should listen on for motion event webhooks from Shinobi
+* `ffmpeg_input_args` are the arguments that are applied to the ffmpeg command before the `-i` flag (add `-rtsp_transport tcp` for poor network conditions)
+* `ffmpeg_process_args` are the arguments that are supplied to the ffmpeg command directly after the source stream URL
 
 If both `https_key_path` and `https_cert_path` are configured to point at HTTPS key and cert files available on the Homebridge
 server the webhook server will be hosted on HTTPS.

--- a/config.schema.json
+++ b/config.schema.json
@@ -53,6 +53,16 @@
         "type": "string",
         "description": "If this AND https_key_path are configured to point at valid files accessible by the platform the webhook server will use HTTPS.",
         "default": "/cert/fullchain.pem"
+      },
+      "ffmpeg_input_args": {
+        "type": "string",
+        "description": "These flags will be added to the ffmpeg command before the `-i` flag",
+        "default": "-fflags +genpts"
+      },
+      "ffmpeg_process_args": {
+        "type": "string",
+        "description": "These flags will be added to the ffmpeg command after the source URL",
+        "default": "-vsync drop -vcodec copy -an"
       }
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -111,13 +111,12 @@ export class ShinobiHomebridgePlatform implements DynamicPlatformPlugin {
         // see if an accessory with the same uuid has already been registered and restored from
         // the cached devices we stored in the `configureAccessory` method above
         const existingAccessory = this.existingAccessories.find(accessory => accessory.UUID === uuid);
-
         if (existingAccessory) {
             // the accessory already exists
             this.log.info(`found existing accessory for UUID: ${uuid} => ${existingAccessory.displayName}`);
 
             // create the accessory handler for the restored accessory
-            this.monitorsByMonitorId.set(monitorId, new ShinobiMonitorAccessory(this, existingAccessory, monitor));
+            this.monitorsByMonitorId.set(monitorId, new ShinobiMonitorAccessory(this, existingAccessory, monitor, this.config));
 
         } else {
             // the accessory does not yet exist, so we need to create it
@@ -127,7 +126,7 @@ export class ShinobiHomebridgePlatform implements DynamicPlatformPlugin {
             const accessory = new this.api.platformAccessory(monitor.displayName, uuid);
 
             // create the accessory handler for the newly created accessory
-            this.monitorsByMonitorId.set(monitorId, new ShinobiMonitorAccessory(this, accessory, monitor));
+            this.monitorsByMonitorId.set(monitorId, new ShinobiMonitorAccessory(this, accessory, monitor, this.config));
 
             // link the accessory to your platform
             this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);

--- a/src/shinobiMonitorAccessory.ts
+++ b/src/shinobiMonitorAccessory.ts
@@ -5,6 +5,7 @@ import {
     H264Profile,
     HAP,
     PlatformAccessory,
+    PlatformConfig,
     Service,
     SRTPCryptoSuites
 } from 'homebridge';
@@ -32,7 +33,8 @@ export class ShinobiMonitorAccessory {
     constructor(
         private readonly platform: ShinobiHomebridgePlatform,
         private readonly accessory: PlatformAccessory,
-        private readonly monitor: Monitor
+        private readonly monitor: Monitor,
+        public readonly config: PlatformConfig
     ) {
 
         // set accessory information
@@ -53,7 +55,7 @@ export class ShinobiMonitorAccessory {
         this.motionService.getCharacteristic(this.platform.Characteristic.MotionDetected)
             .on('get', this.getMotionDetected.bind(this));
 
-        this.shinobiStreamingDelegate = new ShinobiStreamingDelegate(this.platform, this.hap, this.monitor);
+        this.shinobiStreamingDelegate = new ShinobiStreamingDelegate(this.platform, this.hap, this.monitor, this.config);
 
         const options: CameraControllerOptions = {
             cameraStreamCount: 2,

--- a/src/shinobiStreamingDelegate.ts
+++ b/src/shinobiStreamingDelegate.ts
@@ -173,7 +173,10 @@ export class ShinobiStreamingDelegate implements CameraStreamingDelegate {
 
                 this.platform.log.debug(`requested video stream: ${width}x${height}, ${fps} fps, ${maxBitrate} kbps, ${mtu} mtu`);
                 
-                let ffmpegCommand = `${this.config.ffmpeg_input_args} -i ${this.videoSource} ${this.config.ffmpeg_process_args} `
+                const ffmpegInputArgs = this.config.ffmpeg_input_args || '-fflags +genpts';
+                const ffmpegProcessArgs = this.config.ffmpeg_process_args || '-vsync drop -vcodec copy -an';
+
+                let ffmpegCommand = `${ffmpegInputArgs} -i ${this.videoSource} ${ffmpegProcessArgs} `
                     + `-f rtp -payload_type ${payloadType} -ssrc ${ssrc}`;
 
                 ffmpegCommand += ` -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params ${videoSRTP}`;

--- a/src/shinobiStreamingDelegate.ts
+++ b/src/shinobiStreamingDelegate.ts
@@ -7,6 +7,7 @@ import {
     CameraController,
     CameraStreamingDelegate,
     HAP,
+    PlatformConfig,
     PrepareStreamCallback,
     PrepareStreamRequest,
     PrepareStreamResponse,
@@ -51,7 +52,8 @@ export class ShinobiStreamingDelegate implements CameraStreamingDelegate {
     constructor(
         private readonly platform: ShinobiHomebridgePlatform,
         private readonly hap: HAP,
-        private readonly monitor: Monitor
+        private readonly monitor: Monitor,
+        public readonly config: PlatformConfig
     ) {
 
         let shinobiConfig = this.monitor.shinobiConfig;
@@ -170,8 +172,8 @@ export class ShinobiStreamingDelegate implements CameraStreamingDelegate {
                 const videoSRTP = sessionInfo.videoSRTP.toString('base64');
 
                 this.platform.log.debug(`requested video stream: ${width}x${height}, ${fps} fps, ${maxBitrate} kbps, ${mtu} mtu`);
-
-                let ffmpegCommand = `-fflags +genpts -i ${this.videoSource} -vsync drop -vcodec copy -an `
+                
+                let ffmpegCommand = `${this.config.ffmpeg_input_args} -i ${this.videoSource} ${this.config.ffmpeg_process_args} `
                     + `-f rtp -payload_type ${payloadType} -ssrc ${ssrc}`;
 
                 ffmpegCommand += ` -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params ${videoSRTP}`;


### PR DESCRIPTION
### Functionality
Implements the ability for the end user to configure the ffmpeg command to resolve #18 
Allows configuring the ffmpeg command before the `-i` flag, as well as directly after the video source URL is provided to the command.

Updates the README.md and config schema to reflect these changes.

### Use Case
Within #18 poor network conditions led to ffmpeg struggling to encode the video from a source camera over WiFi.
Shinobi handles this by defaulting to TCP, whilst we are not directly copying the Shinobi ffmpeg command, by making it user configurable the option is available for users to tweak how ffmpeg recieves and processes the stream.

### Testing carried out
- Lints
- Builds
- Runs locally
- Upgraded from previous version to this version
- Tested with and without different flags on ffmpeg
- Verified logfiles for Shinobi include the updated ffmpeg command